### PR TITLE
Deprecate skosprovider_sqlalchemy (#124)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,27 @@
 skosprovider_sqlalchemy
 =======================
 
+⚠️ This package is deprecated. Use skosprovider_ instead.
+
+Starting from `skosprovider` 2.0.0 the functionality of this package has been
+merged into the main `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+repository. This package will remain usable with ``skosprovider < 2.0.0``, but is
+no longer actively maintained. It is recommended to upgrade to
+``skosprovider >= 2.0.0`` and use ``skosprovider_sqlalchemy`` from there.
+
+Migrating to skosprovider 2.0.0
+-------------------------------
+
+1. Uninstall ``skosprovider_sqlalchemy`` and install ``skosprovider >= 2.0.0``::
+
+       pip uninstall skosprovider_sqlalchemy
+       pip install "skosprovider>=2.0.0"
+
+2. Replace any ``skosprovider_sqlalchemy`` imports with their equivalent under
+   ``skosprovider`` (see the `skosprovider
+   <https://github.com/OnroerendErfgoed/skosprovider/>`_ documentation for the
+   full mapping).
+
 A SQLAlchemy implementation of the skosprovider_ interface.
 
 .. image:: https://img.shields.io/pypi/v/skosprovider_sqlalchemy.svg
@@ -43,5 +64,5 @@ skosprovider_sqlalchemy is present.
     $ cd docs
     $ make html
 
-.. _skosprovider: https://github.com/koenedaele/skosprovider
+.. _skosprovider: https://github.com/OnroerendErfgoed/skosprovider
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,16 @@
 SkosProvider_SQLAlchemy
 =======================
 
-This library offers an implementation of the 
+.. warning::
+
+   This package is deprecated. Starting from ``skosprovider`` 2.0.0 the
+   functionality of this package has been merged into the main
+   `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+   repository. This package will remain usable with ``skosprovider < 2.0.0``,
+   but is no longer actively maintained. It is recommended to upgrade to
+   ``skosprovider >= 2.0.0`` and use ``skosprovider_sqlalchemy`` from there.
+
+This library offers an implementation of the
 :class:`skosprovider.providers.VocabularyProvider`
 interface that uses a SQLALchemy_ backend. While a 
 :class:`VocabularyProvider <skosprovider.providers.VocabularyProvider>` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "skosprovider_sqlalchemy"
 requires-python = ">=3.11,<3.13"
 keywords = ["rdf", "skos", "skosprovider", "vocabularies", "thesauri"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 7 - Inactive",
     "Programming Language :: Python",
     "Framework :: Pyramid",
     "Topic :: Internet :: WWW/HTTP",
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "SQLAlchemy>=2.0.35",
-    "skosprovider>=1.2.0",
+    "skosprovider>=1.2.0,<2.0.0",
 ]
 
 [project.urls]

--- a/skosprovider_sqlalchemy/__init__.py
+++ b/skosprovider_sqlalchemy/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+warnings.warn(
+    'skosprovider_sqlalchemy is deprecated. Please use `skosprovider>=2.0.0` instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Summary
- Add deprecation banner to README and `.. warning::` block in docs
- Emit `DeprecationWarning` on package import
- Cap `skosprovider` dependency to `<2.0.0` and mark package as `Development Status :: 7 - Inactive`
- Add short migration section pointing to the merged `skosprovider` repo

Refs #124. Version bump and `HISTORY.rst` entry will be added by admin with the final release.
